### PR TITLE
Support Nested Properties

### DIFF
--- a/bwt-datatable.html
+++ b/bwt-datatable.html
@@ -705,7 +705,15 @@
 								if(cell){
 									cell.removeAttribute('data-empty');
 									var prop = cell.dataColumn.property;
-									var data = rowData[prop];
+									
+									var subs = prop.split(".");
+									if (subs.length == 1) {
+										var data = rowData[prop];
+									} else {
+										var data = rowData;
+										subs.forEach(p => data = data[p]);
+									}
+
 									cell.setAttribute('data-row-key', row.dataset.key);
 									cell.dataBoundColumn = cell.dataColumn;
 


### PR DESCRIPTION
**Example usage:**
Assuming a user passes _data_ to _paper-datatable-card_ that contains a JSON object, which contains array of _addresses_, and each address has its own _postal code_. User can add the following to _paper-datatable-column_ component to show the _postal code_ in the table:
  `property="addresses.work.postalCode"`