### PR TITLE
fix #50

### DIFF
--- a/bwt-datatable.html
+++ b/bwt-datatable.html
@@ -687,7 +687,7 @@
 						for(var rowI=0; rowI<rows.length; rowI++){
 							var row = rows[rowI];
 							//find the data that belongs with the row
-							var rowData = this.get(['data',rowI]);
+							var rowData = this._getByKey(row.dataset.key);
 							//prevent errors if row empty
 							if (!rowData) return;
 							var cells = Polymer.dom(row).querySelectorAll('.bound-cell');


### PR DESCRIPTION
this happens there is an internal sort.

when populating row cells, retrieve rowData using the assigned key instead of the `for loop` index,
the `for loop` index retrieves the wrong row when the rows are sorted