### PR TITLE
Fix weird bug where data is shortly null

### DIFF
--- a/bwt-datatable.js
+++ b/bwt-datatable.js
@@ -622,8 +622,8 @@ class PaperDatatable extends mixinBehaviors([IronScrollTargetBehavior, IronResiz
 
 	_setRowKeys() {
 		var rowKeys = [];
-		this._dataKeyCollection = new CollectionHelpers(this.data);
-		this.data.forEach(function (row) {
+		this._dataKeyCollection = new CollectionHelpers(this.data || []);
+		(this.data || []).forEach(function (row) {
 			var key = this._getKeyByItem(row);
 			if ('filter' in this) {
 				if (this.filter(row, key, this.data)) {


### PR DESCRIPTION
Had some problems clicking on rows because data was shortly null, but with this fix, everything works again for us.
WEIRD :D

We got this error when switching selection of a paper-datatable row:
```js
collectionHelpers.js:3 Uncaught TypeError: Cannot read property 'slice' of null
    at new CollectionHelpers (collectionHelpers.js:3)
    at HTMLElement._setRowKeys (bwt-datatable.js:634)
    at Object.runMethodEffect [as fn] (property-effects.js:917)
    at runEffectsForProperty (property-effects.js:168)
    at runEffects (property-effects.js:128)
    at HTMLElement._propertiesChanged (property-effects.js:1888)
    at HTMLElement._flushProperties (properties-changed.js:390)
    at HTMLElement._flushProperties (property-effects.js:1716)
    at HTMLElement.__enableOrFlushClients (property-effects.js:1769)
    at HTMLElement._flushClients (property-effects.js:1741)
```
This led to an error where we weren't notified properly about the change in selection and to change selection one had to select a row twice.

This commit fixed the issue for us.
But I could not find out why the data was null either.

We used a `paper-datatable-card`